### PR TITLE
Language Serialization

### DIFF
--- a/Examplinvi/Examplinvi.csproj
+++ b/Examplinvi/Examplinvi.csproj
@@ -16,6 +16,8 @@
     <SccAuxPath>SAK</SccAuxPath>
     <SccProvider>SAK</SccProvider>
     <TargetFrameworkProfile />
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -119,18 +121,14 @@
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets" Condition="Exists('..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets'))" />
   </Target>
-  <Import Project="..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets" Condition="Exists('..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets')" />
-  <Target Name="EnsureBclBuildImported" BeforeTargets="BeforeBuild" Condition="'$(BclBuildImported)' == ''">
-    <Error Condition="!Exists('..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets')" Text="This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=317567." HelpKeyword="BCLBUILD2001" />
-    <Error Condition="Exists('..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets')" Text="The build restored NuGet packages. Build the project again to include these packages in the build. For more information, see http://go.microsoft.com/fwlink/?LinkID=317568." HelpKeyword="BCLBUILD2002" />
-  </Target>
+  <Import Project="..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets" Condition="Exists('..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/Examplinvi/packages.config
+++ b/Examplinvi/packages.config
@@ -3,7 +3,7 @@
   <package id="Autofac" version="3.5.2" targetFramework="net40" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net40" />
   <package id="Microsoft.Bcl.Async" version="1.0.168" targetFramework="net40" />
-  <package id="Microsoft.Bcl.Build" version="1.0.14" targetFramework="net40" />
+  <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net40" />
   <package id="Microsoft.Net.Http" version="2.2.29" targetFramework="net40" />
   <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net40" />
 </packages>

--- a/Tweetinvi.Core/Extensions/LanguageExtension.cs
+++ b/Tweetinvi.Core/Extensions/LanguageExtension.cs
@@ -33,6 +33,18 @@ namespace Tweetinvi.Core.Extensions
             
         }
 
+        public static Language GetLangFromDescription(int descriptionIndex)
+        {
+            try
+            {
+                return (Language)descriptionIndex;
+            }
+            catch (Exception)
+            {
+                return Language.Undefined;
+            }
+        }
+
         private static bool IsValidDescriptionField(string descriptionValue, FieldInfo field)
         {
             var descriptionAttribute = Attribute.GetCustomAttribute(field, typeof(LanguageAttribute));

--- a/Tweetinvi.Logic/JsonConverters/JsonLanguageConverter.cs
+++ b/Tweetinvi.Logic/JsonConverters/JsonLanguageConverter.cs
@@ -9,7 +9,11 @@ namespace Tweetinvi.Logic.JsonConverters
     {
         public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
         {
-            return LanguageExtension.GetLangFromDescription((string) reader.Value);
+            int parsed = 0;
+            if (int.TryParse(reader.Value.ToString(), out parsed))
+                return LanguageExtension.GetLangFromDescription(parsed);
+            else
+                return LanguageExtension.GetLangFromDescription((string)reader.Value);
         }
 
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)

--- a/Tweetinvi.Logic/JsonConverters/JsonPropertyConverterRepository.cs
+++ b/Tweetinvi.Logic/JsonConverters/JsonPropertyConverterRepository.cs
@@ -193,7 +193,7 @@ namespace Tweetinvi.Logic.JsonConverters
 
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
         {
-            throw new NotImplementedException();
+            serializer.Serialize(writer, value);
         }
     }
 }

--- a/Tweetinvi.Logic/JsonConverters/JsonTwitterDateTimeConverter.cs
+++ b/Tweetinvi.Logic/JsonConverters/JsonTwitterDateTimeConverter.cs
@@ -9,7 +9,7 @@ namespace Tweetinvi.Logic.JsonConverters
     {
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
         {
-            throw new NotImplementedException();
+            serializer.Serialize(writer, value);
         }
 
         public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)


### PR DESCRIPTION
Hello -- Me again. I found another issue related to deserialization of Language on a TweetDTO. Basically here's the scenario

1.) Tweet comes in from Twitter
2.) Tweet JSON is converted into TweetDTO (language is a string at this point -- like "es" or "en")
3.) Language is assigned based on string abbreviation
4.) Tweet DTO is serialized again (in my case to be sent as a message via RabbitMQ)
5.) During serialization the index of the selected Language in the enum is used, not its abbreviation or string value
5.) Tweet is deserialized in preparation for hand-off to ElasticSearch
6.) Error -- An exception of type 'System.InvalidCastException' occurred in Tweetinvi.Logic.dll. Unable to cast object of type 'System.Int64' to type 'System.String'

The above error is thrown in JsonLanguageConverter.ReadJson()

My first approach was to just simply change the cast to reader.Value.ToString() but that resulted in a bunch of "0" values (language not found) in ElasticSearch. Obviously a number like 184 won't apply to the LanguageAttribute description field ("en"). So I had to extend the logic to find the correct Language enum value using either the language abbreviation (original retrieval) or enum index (subsequent retrieval)

The relevant files for this particular change are:
Tweetinvi.Core/Extensions/LanguageExtension.cs
Tweetinvi.Logic/JsonConverters/JsonLanguageConverter.cs

After this change I am seeing consistent values in Kibana after fetching the tweet from Twitter, passing it through RabbitMQ and persisting it to ElasticSearch.