### PR TITLE
Resolves #359 - Adding Accept request header for application/json

### DIFF
--- a/Testinvi/Tweetinvi.Logic/ExtendedTweetTests.cs
+++ b/Testinvi/Tweetinvi.Logic/ExtendedTweetTests.cs
@@ -64,7 +64,7 @@ namespace Testinvi.Tweetinvi.Core
             Assert.AreEqual(tweet.Text, "Check out this photo of @YellowstoneNPS! It makes me want to go camping there this summer. Have you visited before?? nps.gov/yell/index.htm ");
             Assert.AreEqual(tweet.Text.Length, 140);
             Assert.AreEqual(tweet.Suffix, "pic.twitter.com/e8bDiL6LI4");
-            Assert.AreEqual(tweet.Suffix.Length, 24);
+            Assert.AreEqual(tweet.Suffix.Length, 26);
         }
 
         [TestMethod]

--- a/Tweetinvi.WebLogic/TwitterClientHandler.cs
+++ b/Tweetinvi.WebLogic/TwitterClientHandler.cs
@@ -110,6 +110,7 @@ namespace Tweetinvi.WebLogic
             request.Headers.Add("Authorization", authorizationHeader);
             request.Version = new Version("1.1");
             request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("image/jpeg"));
+            request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
 
             return base.SendAsync(request, cancellationToken);
         }


### PR DESCRIPTION
This fix for #359 worked for me when querying the ads API. In the interim, I was able to fix/hack this by overriding the virtual SendAsync method and add the header to the request inside there.

Also, one unit test was not passing so I updated that as well.