### PR TITLE
Issue #383

### DIFF
--- a/Tweetinvi.WebLogic/TwitterRequestHandler.cs
+++ b/Tweetinvi.WebLogic/TwitterRequestHandler.cs
@@ -204,6 +204,8 @@ namespace Tweetinvi.WebLogic
             out ITwitterQuery twitterQuery)
         {
             credentials = credentials ?? _credentialsAccessor.CurrentThreadCredentials;
+            
+            // Why Auth.CredentialsAccessor.CurrentThreadCredentials != _credentialsAccessor.CurrentThreadCredentials ?
 
             if (credentials == null)
             {


### PR DESCRIPTION
About issue #383 I discovered that 
Auth.CredentialsAccessor.CurrentThreadCredentials != _credentialsAccessor.CurrentThreadCredentials
