### PR TITLE
Fixed typos in code

### DIFF
--- a/Tweetinvi.Core/Public/Models/Interfaces/IAuthenticatedUser.cs
+++ b/Tweetinvi.Core/Public/Models/Interfaces/IAuthenticatedUser.cs
@@ -302,27 +302,27 @@ namespace Tweetinvi.Models
         /// <summary>
         /// Subscribe the authenticated user to a list.
         /// </summary>
-        bool SubsribeToList(ITwitterListIdentifier list);
+        bool SubscribeToList(ITwitterListIdentifier list);
 
         /// <summary>
         /// Subscribe the authenticated user to a list.
         /// </summary>
-        bool SubsribeToList(long listId);
+        bool SubscribeToList(long listId);
 
         /// <summary>
         /// Subscribe the authenticated user to a list.
         /// </summary>
-        bool SubsribeToList(string slug, long ownerId);
+        bool SubscribeToList(string slug, long ownerId);
 
         /// <summary>
         /// Subscribe the authenticated user to a list.
         /// </summary>
-        bool SubsribeToList(string slug, string ownerScreenName);
+        bool SubscribeToList(string slug, string ownerScreenName);
 
         /// <summary>
         /// Subscribe the authenticated user to a list.
         /// </summary>
-        bool SubsribeToList(string slug, IUserIdentifier owner);
+        bool SubscribeToList(string slug, IUserIdentifier owner);
 
         /// <summary>
         /// Unsubscribe the authenticated user to a list.

--- a/Tweetinvi.Logic/AuthenticatedUser.cs
+++ b/Tweetinvi.Logic/AuthenticatedUser.cs
@@ -324,27 +324,27 @@ namespace Tweetinvi.Logic
         }
 
         // Twitter Lists
-        public bool SubsribeToList(ITwitterListIdentifier list)
+        public bool SubscribeToList(ITwitterListIdentifier list)
         {
             return ExecuteAuthenticatedUserOperation(() => _twitterListController.SubscribeAuthenticatedUserToList(list));
         }
 
-        public bool SubsribeToList(long listId)
+        public bool SubscribeToList(long listId)
         {
             return ExecuteAuthenticatedUserOperation(() => _twitterListController.SubscribeAuthenticatedUserToList(listId));
         }
 
-        public bool SubsribeToList(string slug, long ownerId)
+        public bool SubscribeToList(string slug, long ownerId)
         {
             return ExecuteAuthenticatedUserOperation(() => _twitterListController.SubscribeAuthenticatedUserToList(slug, ownerId));
         }
 
-        public bool SubsribeToList(string slug, string ownerScreenName)
+        public bool SubscribeToList(string slug, string ownerScreenName)
         {
             return ExecuteAuthenticatedUserOperation(() => _twitterListController.SubscribeAuthenticatedUserToList(slug, ownerScreenName));
         }
 
-        public bool SubsribeToList(string slug, IUserIdentifier owner)
+        public bool SubscribeToList(string slug, IUserIdentifier owner)
         {
             return ExecuteAuthenticatedUserOperation(() => _twitterListController.SubscribeAuthenticatedUserToList(slug, owner));
         }

--- a/Tweetinvi.Logic/TwitterList.cs
+++ b/Tweetinvi.Logic/TwitterList.cs
@@ -216,7 +216,7 @@ namespace Tweetinvi.Logic
         {
             if (authenticatedUser != null)
             {
-                return authenticatedUser.SubsribeToList(this);
+                return authenticatedUser.SubscribeToList(this);
             }
 
             return _twitterListController.SubscribeAuthenticatedUserToList(this);


### PR DESCRIPTION
In this pull request, I changed all instances of "SubsribeToList" to "SubscribeToList".
This will break compatibility with apps that use the typoed function name, but I think completely fixing it is cleaner than merely offering a fixed alternative.
With my changes, Tweetinvi still compiles without any errors, at least on my machine.

Also, this is my first pull request, so please let me know if anything's missing or you require more info.