### PR TITLE
Implement ExcludeReplyUserIds for publishing a Tweet reply

### DIFF
--- a/Tweetinvi.Controllers/Tweet/TweetQueryGenerator.cs
+++ b/Tweetinvi.Controllers/Tweet/TweetQueryGenerator.cs
@@ -94,6 +94,13 @@ namespace Tweetinvi.Controllers.Tweet
                 if (queryParameters.InReplyToTweet != null)
                 {
                     query.AddParameterToQuery("in_reply_to_status_id", queryParameters.InReplyToTweet.Id);
+
+                    // Extended Tweet prefix auto-population
+                    query.AddParameterToQuery("auto_populate_reply_metadata", queryParameters.AutoPopulateReplyMetadata);
+                    if (queryParameters.ExcludeReplyUserIds != null)
+                    {
+                        query.AddParameterToQuery("exclude_reply_user_ids", String.Join(",", queryParameters.ExcludeReplyUserIds));
+                    }
                 }
 
                 query.AddParameterToQuery("possibly_sensitive", queryParameters.PossiblySensitive);
@@ -107,9 +114,7 @@ namespace Tweetinvi.Controllers.Tweet
                 query.AddParameterToQuery("place_id", queryParameters.PlaceId);
                 query.AddParameterToQuery("display_coordinates", queryParameters.DisplayExactCoordinates);
                 query.AddParameterToQuery("trim_user", queryParameters.TrimUser);
-                query.AddParameterToQuery("auto_populate_reply_metadata", queryParameters.AutoPopulateReplyMetadata);
                 query.AddParameterToQuery("tweet_mode", _tweetinviSettingsAccessor.CurrentThreadSettings.TweetMode?.ToString().ToLowerInvariant());
-                query.AddParameterToQuery("exclude_reply_userids", queryParameters.ExcludeReplyUserIds);
 
                 if (useExtendedMode && quotedTweetUrl != null)
                 {

--- a/Tweetinvi.Controllers/Tweet/TweetQueryGenerator.cs
+++ b/Tweetinvi.Controllers/Tweet/TweetQueryGenerator.cs
@@ -99,7 +99,8 @@ namespace Tweetinvi.Controllers.Tweet
                     query.AddParameterToQuery("auto_populate_reply_metadata", queryParameters.AutoPopulateReplyMetadata);
                     if (queryParameters.ExcludeReplyUserIds != null)
                     {
-                        query.AddParameterToQuery("exclude_reply_user_ids", String.Join(",", queryParameters.ExcludeReplyUserIds));
+                        // Use URL encoded comma %2C so we don't need to URL encode the string afterwards
+                        query.AddParameterToQuery("exclude_reply_user_ids", String.Join("%2C", queryParameters.ExcludeReplyUserIds));
                     }
                 }
 

--- a/Tweetinvi.Core/Public/Parameters/PublishTweetOptionalParameters.cs
+++ b/Tweetinvi.Core/Public/Parameters/PublishTweetOptionalParameters.cs
@@ -68,12 +68,21 @@ namespace Tweetinvi.Parameters
         bool? TrimUser { get; set; }
 
         /// <summary>
-        /// Twitter will move the @mentions to the extended tweet prefix.
+        /// Twitter will auto-populate the @mentions in the extended tweet prefix from the Tweet
+        /// being replied to, plus a mention of the screen name that posted the Tweet being replied to.
+        /// i.e. This auto-populates a "reply all".
+        /// Must be used with InReplyToTweetId or InReplyToTweet.
+        /// Use ExcludeReplyUserIds to specify accounts to not mention in the prefix.
+        /// Also note that there can be a maximum of 50 mentions in the prefix, any more will error.
         /// </summary>
         bool? AutoPopulateReplyMetadata { get; set; }
 
-        // Twitter has not documented this parameter yet!
-        bool? ExcludeReplyUserIds { get; set; }
+        /// <summary>
+        /// Twitter User IDs to not include in the auto-populated extended Tweet prefix.
+        /// Cannot exclude the User who is directly being replied to, only the additional mentions.
+        /// Must be used with AutoPopulateReplyMetadata.
+        /// </summary>
+        IEnumerable<long> ExcludeReplyUserIds { get; set; }
     }
 
     /// <summary>
@@ -133,6 +142,6 @@ namespace Tweetinvi.Parameters
         public bool? PossiblySensitive { get; set; }
         public bool? TrimUser { get; set; }
         public bool? AutoPopulateReplyMetadata { get; set; }
-        public bool? ExcludeReplyUserIds { get; set; }
+        public IEnumerable<long> ExcludeReplyUserIds { get; set; }
     }
 }

--- a/Tweetinvi.Core/Public/Parameters/PublishTweetParameters.cs
+++ b/Tweetinvi.Core/Public/Parameters/PublishTweetParameters.cs
@@ -10,7 +10,7 @@ namespace Tweetinvi.Parameters
     public interface IPublishTweetParameters : ICustomRequestParameters
     {
         /// <summary>
-        /// Message to publish as a twwweet
+        /// Message to publish as a tweet
         /// </summary>
         string Text { get; }
 
@@ -80,12 +80,22 @@ namespace Tweetinvi.Parameters
         /// </summary>
         bool? TrimUser { get; set; }
 
-        bool? ExcludeReplyUserIds { get; set; }
-
         /// <summary>
-        /// Twitter will move the @mentions to the extended tweet prefix.
+        /// Twitter will auto-populate the @mentions in the extended tweet prefix from the Tweet
+        /// being replied to, plus a mention of the screen name that posted the Tweet being replied to.
+        /// i.e. This auto-populates a "reply all".
+        /// Must be used with InReplyToTweetId or InReplyToTweet.
+        /// Use ExcludeReplyUserIds to specify accounts to not mention in the prefix.
+        /// Also note that there can be a maximum of 50 mentions in the prefix, any more will error.
         /// </summary>
         bool? AutoPopulateReplyMetadata { get; set; }
+
+        /// <summary>
+        /// Twitter User IDs to not include in the auto-populated extended Tweet prefix.
+        /// Cannot exclude the User who is directly being replied to, only the additional mentions.
+        /// Must be used with AutoPopulateReplyMetadata.
+        /// </summary>
+        IEnumerable<long> ExcludeReplyUserIds { get; set; }
 
         #endregion
     }
@@ -167,7 +177,7 @@ namespace Tweetinvi.Parameters
             set { Parameters.TrimUser = value; }
         }
 
-        public bool? ExcludeReplyUserIds
+        public IEnumerable<long> ExcludeReplyUserIds
         {
             get { return Parameters.ExcludeReplyUserIds; }
             set { Parameters.ExcludeReplyUserIds = value; }


### PR DESCRIPTION
See #487 

Twitter has launched the prefix portion of their new extended tweets.
Tweetinvi had stubbed, but not implemented ExcludeReplyUserIds for that & this PR just implements it.

ExcludeReplyUserIds is required to manage the auto-population of the prefix, otherwise Twitter will always "reply-all" the Tweet you're replying to. It could also be needed to manage the mentions for very lengthy chains of replies, as the prefix is limited to containing 50 mentions.

Example usage:
```cs
Tweet.PublishTweet("testing 123 this tweet is over 140 chars, but that's fine because the initial mention is no longer counted! yay yay yay yay yay yay yay!2", 
                new PublishTweetOptionalParameters()
{
    InReplyToTweetId = 860111840101224449,
    AutoPopulateReplyMetadata = true,
    ExcludeReplyUserIds = new long[] { 1728100111 }
 });
```
publishes https://twitter.com/VISAVJoe/status/860119905504546816

And without ExcludeReplyUserIds publishes https://twitter.com/VISAVJoe/status/860111956707028993