### PR TITLE
fix #499 - Credentials threading bug

### DIFF
--- a/Tweetinvi.Credentials/CredentialsAccessor.cs
+++ b/Tweetinvi.Credentials/CredentialsAccessor.cs
@@ -47,6 +47,8 @@ namespace Tweetinvi.Credentials
             set
             {
                 _currentThreadCredentials = value;
+                // Mark as initialised, don't want to override these credentials the user has set with application ones when we first use them
+                _currentThreadCredentialsInitialized = true;
 
                 if (!HasTheApplicationCredentialsBeenInitialized() && _currentThreadCredentials != null)
                 {


### PR DESCRIPTION
When the current thread's credentials had been set before being accessed it would discard them and replace them with the static application ones on first use.

See #499 for more info & repro.