### PR TITLE
Add Credentials to ITwitterException

### DIFF
--- a/Testinvi/TweetinviControllers/TweetTests/TweetQueryExecutorTests.cs
+++ b/Testinvi/TweetinviControllers/TweetTests/TweetQueryExecutorTests.cs
@@ -40,13 +40,16 @@ namespace Testinvi.TweetinviControllers.TweetTests
 
             var fakeWebExceptionInfoExtractor = A.Fake<IWebExceptionInfoExtractor>();
 
+            var credentials = new TwitterCredentials(TestHelper.GenerateString(), TestHelper.GenerateString(),
+                TestHelper.GenerateString(), TestHelper.GenerateString());
+
             var twitter139ExceptionInfos = new TwitterExceptionInfo { Code = 139 };
             fakeWebExceptionInfoExtractor.CallsTo(x => x.GetTwitterExceptionInfo(It.IsAny<WebException>())).Returns(new[] { twitter139ExceptionInfos });
-            _fake139TwitterException = new TwitterException(fakeWebExceptionInfoExtractor, new WebException(), TestHelper.GenerateString());
+            _fake139TwitterException = new TwitterException(fakeWebExceptionInfoExtractor, new WebException(), TestHelper.GenerateString(), credentials);
 
             var twitterOtherExceptionInfos = new TwitterExceptionInfo { Code = 1 };
             fakeWebExceptionInfoExtractor.CallsTo(x => x.GetTwitterExceptionInfo(It.IsAny<WebException>())).Returns(new[] { twitterOtherExceptionInfos });
-            _fakeOtherTwitterException = new TwitterException(fakeWebExceptionInfoExtractor, new WebException(), TestHelper.GenerateString());
+            _fakeOtherTwitterException = new TwitterException(fakeWebExceptionInfoExtractor, new WebException(), TestHelper.GenerateString(), credentials);
 
             _cursorQueryIds = new List<long>();
         }

--- a/Tweetinvi.Core/Core/Exceptions/IExceptionHandler.cs
+++ b/Tweetinvi.Core/Core/Exceptions/IExceptionHandler.cs
@@ -4,6 +4,7 @@ using System.Net;
 using Tweetinvi.Core.Web;
 using Tweetinvi.Events;
 using Tweetinvi.Exceptions;
+using Tweetinvi.Models;
 
 namespace Tweetinvi.Core.Exceptions
 {
@@ -19,16 +20,18 @@ namespace Tweetinvi.Core.Exceptions
 
         void ClearLoggedExceptions();
 
-        TwitterException AddWebException(WebException webException, string url);
-        TwitterException TryLogWebException(WebException webException, string url);
+        TwitterException AddWebException(WebException webException, string url, ITwitterCredentials credentials);
+        TwitterException TryLogWebException(WebException webException, string url, ITwitterCredentials credentials);
 
-        TwitterException AddFailedWebRequestResult(IWebRequestResult webRequestResult);
-        TwitterException TryLogFailedWebRequestResult(IWebRequestResult webRequestResult);
+        TwitterException AddFailedWebRequestResult(IWebRequestResult webRequestResult, ITwitterCredentials credentials);
+        TwitterException TryLogFailedWebRequestResult(IWebRequestResult webRequestResult, ITwitterCredentials credentials);
 
-        TwitterException TryLogExceptionInfos(ITwitterExceptionInfo[] exceptionInfos, string url);
+        TwitterException TryLogExceptionInfos(ITwitterExceptionInfo[] exceptionInfos, string url,
+            ITwitterCredentials credentials);
 
-        TwitterException GenerateTwitterException(WebException webException, string url);
-        TwitterException GenerateTwitterException(IWebRequestResult webRequestResult);
+        TwitterException GenerateTwitterException(WebException webException, string url,
+            ITwitterCredentials credentials);
+        TwitterException GenerateTwitterException(IWebRequestResult webRequestResult, ITwitterCredentials credentials);
         void AddTwitterException(ITwitterException twitterException);
     }
 }

--- a/Tweetinvi.Core/Core/Exceptions/ITwitterException.cs
+++ b/Tweetinvi.Core/Core/Exceptions/ITwitterException.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Net;
+using Tweetinvi.Models;
 
 namespace Tweetinvi.Core.Exceptions
 {
@@ -13,5 +14,10 @@ namespace Tweetinvi.Core.Exceptions
         string TwitterDescription { get; }
         DateTime CreationDate { get; }
         IEnumerable<ITwitterExceptionInfo> TwitterExceptionInfos { get; }
+
+        /// <summary>
+        /// The credentials used to make the request that gave this exception
+        /// </summary>
+        ITwitterCredentials Credentials { get; }
     }
 }

--- a/Tweetinvi.Core/Public/Exceptions/TwitterTimeoutException.cs
+++ b/Tweetinvi.Core/Public/Exceptions/TwitterTimeoutException.cs
@@ -13,8 +13,9 @@ namespace Tweetinvi.Exceptions
 
     public class TwitterTimeoutException : TwitterException, ITwitterTimeoutException
     {
-        public TwitterTimeoutException(ITwitterQuery twitterQuery) 
-            : base(twitterQuery.QueryURL, string.Format("{0} web request timed out.", twitterQuery.QueryURL))
+        public TwitterTimeoutException(ITwitterQuery twitterQuery)
+            : base(twitterQuery.QueryURL, twitterQuery.TwitterCredentials,
+                string.Format("{0} web request timed out.", twitterQuery.QueryURL))
         {
             Timeout = twitterQuery.Timeout;
             TwitterDescription = string.Format("Twitter was not able to perform your query within the Timeout limit of {0} ms.", twitterQuery.Timeout.TotalMilliseconds);

--- a/Tweetinvi.Credentials/AuthFactory.cs
+++ b/Tweetinvi.Credentials/AuthFactory.cs
@@ -130,7 +130,7 @@ namespace Tweetinvi.Credentials
                 var errorsObject = jobject["errors"];
                 var errors = _jObjectStaticWrapper.ToObject<ITwitterExceptionInfo[]>(errorsObject);
 
-                _exceptionHandler.TryLogExceptionInfos(errors, url);
+                _exceptionHandler.TryLogExceptionInfos(errors, url, credentials);
             }
             catch (Exception)
             {

--- a/Tweetinvi.Logic/Exceptions/ExceptionHandler.cs
+++ b/Tweetinvi.Logic/Exceptions/ExceptionHandler.cs
@@ -7,6 +7,7 @@ using Tweetinvi.Core.Exceptions;
 using Tweetinvi.Core.Web;
 using Tweetinvi.Events;
 using Tweetinvi.Exceptions;
+using Tweetinvi.Models;
 
 namespace Tweetinvi.Logic.Exceptions
 {
@@ -52,9 +53,9 @@ namespace Tweetinvi.Logic.Exceptions
             }
         }
 
-        public TwitterException AddWebException(WebException webException, string url)
+        public TwitterException AddWebException(WebException webException, string url, ITwitterCredentials credentials)
         {
-            var twitterException = GenerateTwitterException(webException, url);
+            var twitterException = GenerateTwitterException(webException, url, credentials);
 
             AddTwitterException(twitterException);
 
@@ -62,9 +63,10 @@ namespace Tweetinvi.Logic.Exceptions
             return twitterException;
         }
 
-        public TwitterException TryLogWebException(WebException webException, string url)
+        public TwitterException TryLogWebException(WebException webException, string url,
+            ITwitterCredentials credentials)
         {
-            var twitterException = GenerateTwitterException(webException, url);
+            var twitterException = GenerateTwitterException(webException, url, credentials);
 
             if (LogExceptions)
             {
@@ -74,9 +76,10 @@ namespace Tweetinvi.Logic.Exceptions
             return twitterException;
         }
 
-        public TwitterException TryLogExceptionInfos(ITwitterExceptionInfo[] exceptionInfos, string url)
+        public TwitterException TryLogExceptionInfos(ITwitterExceptionInfo[] exceptionInfos, string url,
+            ITwitterCredentials credentials)
         {
-            var twitterException = _twitterExceptionFactory.Create(exceptionInfos, url);
+            var twitterException = _twitterExceptionFactory.Create(exceptionInfos, url, credentials);
 
             if (LogExceptions)
             {
@@ -86,18 +89,20 @@ namespace Tweetinvi.Logic.Exceptions
             return twitterException;
         }
 
-        public TwitterException AddFailedWebRequestResult(IWebRequestResult webRequestResult)
+        public TwitterException AddFailedWebRequestResult(IWebRequestResult webRequestResult,
+            ITwitterCredentials credentials)
         {
-            var twitterException = GenerateTwitterException(webRequestResult);
+            var twitterException = GenerateTwitterException(webRequestResult, credentials);
 
             AddTwitterException(twitterException);
             
             return twitterException;
         }
 
-        public TwitterException TryLogFailedWebRequestResult(IWebRequestResult webRequestResult)
+        public TwitterException TryLogFailedWebRequestResult(IWebRequestResult webRequestResult,
+            ITwitterCredentials credentials)
         {
-            var twitterException = GenerateTwitterException(webRequestResult);
+            var twitterException = GenerateTwitterException(webRequestResult, credentials);
 
             if (LogExceptions)
             {
@@ -107,19 +112,22 @@ namespace Tweetinvi.Logic.Exceptions
             return twitterException;
         }
 
-        public TwitterException GenerateTwitterException(ITwitterExceptionInfo[] exceptionInfos, string url)
+        public TwitterException GenerateTwitterException(ITwitterExceptionInfo[] exceptionInfos, string url,
+            ITwitterCredentials credentials)
         {
-            return _twitterExceptionFactory.Create(exceptionInfos, url);
+            return _twitterExceptionFactory.Create(exceptionInfos, url, credentials);
         }
 
-        public TwitterException GenerateTwitterException(WebException webException, string url)
+        public TwitterException GenerateTwitterException(WebException webException, string url,
+            ITwitterCredentials credentials)
         {
-            return _twitterExceptionFactory.Create(webException, url);
+            return _twitterExceptionFactory.Create(webException, url, credentials);
         }
 
-        public TwitterException GenerateTwitterException(IWebRequestResult webRequestResult)
+        public TwitterException GenerateTwitterException(IWebRequestResult webRequestResult,
+            ITwitterCredentials credentials)
         {
-            return _twitterExceptionFactory.Create(webRequestResult);
+            return _twitterExceptionFactory.Create(webRequestResult, credentials);
         }
 
         public void AddTwitterException(ITwitterException twitterException)

--- a/Tweetinvi.Streams/StreamTask.cs
+++ b/Tweetinvi.Streams/StreamTask.cs
@@ -338,7 +338,9 @@ namespace Tweetinvi.Streams
 
         private void HandleWebException(WebException wex)
         {
-            _lastException = _exceptionHandler.GenerateTwitterException(wex, _twitterQuery.QueryURL);
+            _lastException =
+                _exceptionHandler.GenerateTwitterException(wex, _twitterQuery.QueryURL,
+                    _twitterQuery.TwitterCredentials);
 
             if (!_exceptionHandler.SwallowWebExceptions)
             {

--- a/Tweetinvi.WebLogic/WebRequestExecutor.cs
+++ b/Tweetinvi.WebLogic/WebRequestExecutor.cs
@@ -48,7 +48,7 @@ namespace Tweetinvi.WebLogic
 
                     if (!result.IsSuccessStatusCode)
                     {
-                        throw _exceptionHandler.TryLogFailedWebRequestResult(result);
+                        throw _exceptionHandler.TryLogFailedWebRequestResult(result, twitterQuery.TwitterCredentials);
                     }
 
                     var stream = result.ResultStream;
@@ -150,7 +150,8 @@ namespace Tweetinvi.WebLogic
 
                 if (webException != null)
                 {
-                    throw _exceptionHandler.TryLogWebException(webException, twitterQuery.QueryURL);
+                    throw _exceptionHandler.TryLogWebException(webException, twitterQuery.QueryURL,
+                        twitterQuery.TwitterCredentials);
                 }
 
                 if (taskCanceledException != null)

--- a/Tweetinvi/ExceptionHandler.cs
+++ b/Tweetinvi/ExceptionHandler.cs
@@ -6,6 +6,7 @@ using System.Text;
 using Tweetinvi.Core.Exceptions;
 using Tweetinvi.Events;
 using Tweetinvi.Exceptions;
+using Tweetinvi.Models;
 
 namespace Tweetinvi
 {
@@ -89,9 +90,10 @@ namespace Tweetinvi
         /// <summary>
         /// Ask for the ExceptionHandler to handle an Exception.
         /// </summary>
-        public static TwitterException AddWebException(WebException webException, string url)
+        public static TwitterException AddWebException(WebException webException, string url,
+            ITwitterCredentials credentials)
         {
-            return CurrentThreadExceptionHandler.AddWebException(webException, url);
+            return CurrentThreadExceptionHandler.AddWebException(webException, url, credentials);
         }
 
         /// <summary>
@@ -113,9 +115,10 @@ namespace Tweetinvi
         /// <summary>
         /// Returns a TwitterException from a WebException.
         /// </summary>
-        public static ITwitterException GenerateTwitterException(WebException webException, string url)
+        public static ITwitterException GenerateTwitterException(WebException webException, string url,
+            ITwitterCredentials credentials)
         {
-            return CurrentThreadExceptionHandler.GenerateTwitterException(webException, url);
+            return CurrentThreadExceptionHandler.GenerateTwitterException(webException, url, credentials);
         }
 
         /// <summary>


### PR DESCRIPTION
Makes the credentials used to make the request accessible on ITwitterException.

When using many credentials to make requests and exceptions are handled from some centralised code, it makes sense to be able to see which credentials were used to make the request that gave the exception.  
  
My main use case for this is auto-pruning invalid or expired tokens.