### PR TITLE
Bug Fix: Stream HTTP response code not getting included in TwitterException

### DIFF
--- a/Tweetinvi.Core/Core/Exceptions/IExceptionHandler.cs
+++ b/Tweetinvi.Core/Core/Exceptions/IExceptionHandler.cs
@@ -27,7 +27,8 @@ namespace Tweetinvi.Core.Exceptions
 
         TwitterException TryLogExceptionInfos(ITwitterExceptionInfo[] exceptionInfos, string url);
 
-        TwitterException GenerateTwitterException(WebException webException, string url);
+        TwitterException GenerateTwitterException(WebException webException, string url,
+            int defaultStatusCode = TwitterException.DEFAULT_STATUS_CODE);
         TwitterException GenerateTwitterException(IWebRequestResult webRequestResult);
         void AddTwitterException(ITwitterException twitterException);
     }

--- a/Tweetinvi.Core/Core/Exceptions/IWebExceptionInfoExtractor.cs
+++ b/Tweetinvi.Core/Core/Exceptions/IWebExceptionInfoExtractor.cs
@@ -6,7 +6,7 @@ namespace Tweetinvi.Core.Exceptions
 {
     public interface IWebExceptionInfoExtractor
     {
-        int GetWebExceptionStatusNumber(WebException wex);
+        int GetWebExceptionStatusNumber(WebException wex, int defaultCode);
         string GetStatusCodeDescription(int statusCode);
         IEnumerable<ITwitterExceptionInfo> GetTwitterExceptionInfo(WebException wex);
         IEnumerable<ITwitterExceptionInfo> GetTwitterExceptionInfosFromStream(Stream stream);

--- a/Tweetinvi.Core/Public/Exceptions/TwitterException.cs
+++ b/Tweetinvi.Core/Public/Exceptions/TwitterException.cs
@@ -10,7 +10,9 @@ namespace Tweetinvi.Exceptions
     {
         TwitterException Create(ITwitterExceptionInfo[] exceptionInfos, string url);
         TwitterException Create(IWebRequestResult webRequestResult);
-        TwitterException Create(WebException webException, string url);
+
+        TwitterException Create(WebException webException, string url,
+            int statusCode = TwitterException.DEFAULT_STATUS_CODE);
     }
 
     public class TwitterExceptionFactory : ITwitterExceptionFactory
@@ -32,14 +34,17 @@ namespace Tweetinvi.Exceptions
             return new TwitterException(_webExceptionInfoExtractor, webRequestResult);
         }
 
-        public TwitterException Create(WebException webException, string url)
+        public TwitterException Create(WebException webException, string url,
+            int defaultStatusCode = TwitterException.DEFAULT_STATUS_CODE)
         {
-            return new TwitterException(_webExceptionInfoExtractor, webException, url);
+            return new TwitterException(_webExceptionInfoExtractor, webException, url, defaultStatusCode);
         }
     }
 
     public class TwitterException : WebException, ITwitterException
     {
+        public const int DEFAULT_STATUS_CODE = -1;
+
         public virtual WebException WebException { get; protected set; }
         public virtual string URL { get; set; }
         public virtual int StatusCode { get; protected set; }
@@ -79,11 +84,12 @@ namespace Tweetinvi.Exceptions
         public TwitterException(
             IWebExceptionInfoExtractor webExceptionInfoExtractor,
             WebException webException,
-            string url)
+            string url,
+            int defaultStatusCode = DEFAULT_STATUS_CODE)
             : this(url, webException.Message)
         {
             WebException = webException;
-            StatusCode = webExceptionInfoExtractor.GetWebExceptionStatusNumber(webException);
+            StatusCode = webExceptionInfoExtractor.GetWebExceptionStatusNumber(webException, defaultStatusCode);
             TwitterExceptionInfos = webExceptionInfoExtractor.GetTwitterExceptionInfo(webException);
             TwitterDescription = webExceptionInfoExtractor.GetStatusCodeDescription(StatusCode);
         }

--- a/Tweetinvi.Logic/Exceptions/ExceptionHandler.cs
+++ b/Tweetinvi.Logic/Exceptions/ExceptionHandler.cs
@@ -112,9 +112,10 @@ namespace Tweetinvi.Logic.Exceptions
             return _twitterExceptionFactory.Create(exceptionInfos, url);
         }
 
-        public TwitterException GenerateTwitterException(WebException webException, string url)
+        public TwitterException GenerateTwitterException(WebException webException, string url,
+            int defaultStatusCode = TwitterException.DEFAULT_STATUS_CODE)
         {
-            return _twitterExceptionFactory.Create(webException, url);
+            return _twitterExceptionFactory.Create(webException, url, defaultStatusCode);
         }
 
         public TwitterException GenerateTwitterException(IWebRequestResult webRequestResult)

--- a/Tweetinvi.Logic/Exceptions/WebExceptionInfoExtractor.cs
+++ b/Tweetinvi.Logic/Exceptions/WebExceptionInfoExtractor.cs
@@ -23,7 +23,7 @@ namespace Tweetinvi.Logic.Exceptions
             _twitterExceptionInfoUnityFactory = twitterExceptionInfoUnityFactory;
         }
 
-        public int GetWebExceptionStatusNumber(WebException wex)
+        public int GetWebExceptionStatusNumber(WebException wex, int defaultCode)
         {
             var wexResponse = wex.Response as HttpWebResponse;
             if (wexResponse != null)
@@ -31,7 +31,7 @@ namespace Tweetinvi.Logic.Exceptions
                 return (int)wexResponse.StatusCode;
             }
 
-            return -1;
+            return defaultCode;
         }
 
         public string GetStatusCodeDescription(int statusCode)

--- a/Tweetinvi.Streams/StreamTask.cs
+++ b/Tweetinvi.Streams/StreamTask.cs
@@ -53,6 +53,7 @@ namespace Tweetinvi.Streams
         private ITwitterQuery _twitterQuery;
         private StreamReader _currentStreamReader;
         private HttpClient _currentHttpClient;
+        private int _currentResponseHttpStatusCode = TwitterException.DEFAULT_STATUS_CODE;
 
         public StreamTask(
             Func<string, bool> processObject,
@@ -215,6 +216,7 @@ namespace Tweetinvi.Streams
 
 
                 var response = await client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead).ConfigureAwait(false);
+                _currentResponseHttpStatusCode = (int) response.StatusCode;
                 var body = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
 
                 return new StreamReader(body, Encoding.GetEncoding("utf-8"));
@@ -338,7 +340,8 @@ namespace Tweetinvi.Streams
 
         private void HandleWebException(WebException wex)
         {
-            _lastException = _exceptionHandler.GenerateTwitterException(wex, _twitterQuery.QueryURL);
+            _lastException =
+                _exceptionHandler.GenerateTwitterException(wex, _twitterQuery.QueryURL, _currentResponseHttpStatusCode);
 
             if (!_exceptionHandler.SwallowWebExceptions)
             {


### PR DESCRIPTION
The HTTP status code from the response of a connection to the streaming API isn't getting included in the TwitterException thrown.

This PR adds it in.

This feels quite messy so I wouldn't actually merge this, but it shows how the actual status code can be accessed. It feels like there should be a nicer way of passing the status code over to the webExceptionInfoExtractor just for streams, but I don't know the code well enough and we needed a quick fix! :)