### PR TITLE
Fixed NullReferenceException in RateLimitUpdater 

### DIFF
--- a/Tweetinvi.Credentials/RateLimit/RateLimitUpdater.cs
+++ b/Tweetinvi.Credentials/RateLimit/RateLimitUpdater.cs
@@ -42,6 +42,8 @@ namespace Tweetinvi.Credentials.RateLimit
             if (rateLimitHeaders != null && rateLimitHeaders.Count > 0)
             {
                 var rateLimit = _rateLimitCacheManager.GetOrCreateQueryRateLimit(query, credentials);
+                if (rateLimit == null)
+                    return;
 
                 IEnumerable<string> limitHeaders;
                 if (rateLimitHeaders.TryGetValue("x-rate-limit-limit", out limitHeaders))


### PR DESCRIPTION
Fixed NullReferenceException in RateLimitUpdater when rate limit information returned by `GetOrCreateQueryRateLimit` is null.

This commit is targeted on 1.3