### PR TITLE
Fix AddMultipleMembers() family of methods for Twitter Lists

### DIFF
--- a/Tweetinvi.Controllers/User/UserQueryParameterGenerator.cs
+++ b/Tweetinvi.Controllers/User/UserQueryParameterGenerator.cs
@@ -84,7 +84,7 @@ namespace Tweetinvi.Controllers.User
 
             for (int i = 0; i < usersList.Count - 1; ++i)
             {
-                var userDTO = usersList[0];
+                var userDTO = usersList[i];
 
                 if (userDTO.Id != TweetinviSettings.DEFAULT_ID)
                 {


### PR DESCRIPTION
The AddMultipleMembers() family of methods for Twitter Lists were broken. They were only adding the 1st and last users in any given list (up to 100) of users. A one-character-fix!