### PR TITLE
Update logic to count Unicode text elements and create Unicode substrings

### DIFF
--- a/Testinvi/Tweetinvi.Core/StringExtensionsTests.cs
+++ b/Testinvi/Tweetinvi.Core/StringExtensionsTests.cs
@@ -228,7 +228,7 @@ namespace Testinvi.Tweetinvi.Core
             public void TweetLengthWithSpecialUTFCharacters()
             {
                 var l = Tweet.Length("sa 🎅⛄️🎅 done");
-                Assert.AreEqual(l, 12);
+                Assert.AreEqual(11, l);
             }
 
             [TestMethod]

--- a/Testinvi/Tweetinvi.Core/UnicodeHelperTests.cs
+++ b/Testinvi/Tweetinvi.Core/UnicodeHelperTests.cs
@@ -9,23 +9,133 @@ namespace Testinvi.Tweetinvi.Core
         [TestMethod]
         public void UnicodeLength()
         {
-            Assert.AreEqual(UnicodeHelper.UTF32Length("sa🚒osa"), 6);
-            Assert.AreEqual(UnicodeHelper.UTF32Length("ab 🎅🏼⛄️🎅🏼 yz"), 12);
-            Assert.AreEqual(UnicodeHelper.UTF32Length("🎅🏼⛄️🎅🏼"), 6);
-            Assert.AreEqual(UnicodeHelper.UTF32Length("Cooper`s Hawk"), 13);
+            Assert.AreEqual(6, UnicodeHelper.UTF32Length("sa🚒osa"));
+            Assert.AreEqual(11, UnicodeHelper.UTF32Length("ab 🎅🏼⛄️🎅🏼 yz"));
+            Assert.AreEqual(5, UnicodeHelper.UTF32Length("🎅🏼⛄️🎅🏼"));
+            Assert.AreEqual(5, UnicodeHelper.UTF32Length("\ud83c\udf85\ud83c\udffc\u26c4\ufe0f\ud83c\udf85\ud83c\udffc"));
+            Assert.AreEqual(2, UnicodeHelper.UTF32Length("\ud83c\udfb8\u203c\ufe0f"));
+            Assert.AreEqual(13, UnicodeHelper.UTF32Length("Cooper`s Hawk"));
+        }
+    }
+
+    [TestClass]
+    public class UnicodeHelperSubstringByTextElementsTests
+    {
+        [TestMethod]
+        public void When_Input_Is_Null_Then_Result_Is_Null()
+        {
+            Assert.IsNull(UnicodeHelper.SubstringByTextElements(null, 0));
+            Assert.IsNull(UnicodeHelper.SubstringByTextElements(null, 0, 1));
         }
 
         [TestMethod]
-        public void UnicodeSubstring()
+        public void When_StartIndex_Equals_Zero_Then_Result_Equals_Input()
         {
-            // Arrange
+            var str = "abcd";
+            var substr = UnicodeHelper.SubstringByTextElements(str, 0);
+            Assert.AreEqual(str, substr);
+        }
+
+        [TestMethod]
+        public void When_StartIndex_GreaterThan_Zero_Then_Result_Contains_Part_Of_Input()
+        {
+            var str = "abcd";
+            var substr = UnicodeHelper.SubstringByTextElements(str, 1);
+            Assert.AreEqual("bcd", substr);
+        }
+
+        [TestMethod]
+        public void When_StartIndex_Equals_InputLength_Then_Result_Is_Empty()
+        {
+            var str = "abcd";
+            var substr = UnicodeHelper.SubstringByTextElements(str, str.Length);
+            Assert.AreEqual("", substr);
+        }
+
+        [TestMethod]
+        public void When_StartIndex_GreaterThan_InputLength_Then_Result_Is_Empty()
+        {
+            var str = "abcd";
+            var substr = UnicodeHelper.SubstringByTextElements(str, str.Length + 1);
+            Assert.AreEqual("", substr);
+        }
+
+        [TestMethod]
+        public void When_Input_Contains_Emojis_And_StartIndex_Equals_Zero_Then_Result_Equals_Input()
+        {
+            var str = "🎅🏼⛄️🎅🏼";
+            var substr = UnicodeHelper.SubstringByTextElements(str, 0);
+            Assert.AreEqual(str, substr);
+        }
+
+        [TestMethod]
+        public void When_Input_Contains_Emojis_And_StartIndex_Is_After_Emojis_Then_Result_Contains_No_Emojis()
+        {
+            var str = "🎅🏼⛄️🎅🏼abcd";
+            var substr = UnicodeHelper.SubstringByTextElements(str, 5);
+            Assert.AreEqual("abcd", substr);
+        }
+
+        [TestMethod]
+        public void When_Input_Contains_Emojis_And_StartIndex_Is_Between_Emojis_Then_Result_Contains_Emojis()
+        {
+            var str = "🎅🏼⛄️🎅🏼abcd";
+            var substr = UnicodeHelper.SubstringByTextElements(str, 3);
+            Assert.AreEqual("🎅🏼abcd", substr);
+        }
+
+        [TestMethod]
+        public void When_StartIndex_Equals_Zero_And_Length_Equals_Zero_Then_Result_Is_Empty()
+        {
+            var str = "abcd";
+            var substr = UnicodeHelper.SubstringByTextElements(str, 0, 0);
+            Assert.AreEqual("", substr);
+        }
+
+        [TestMethod]
+        public void When_StartIndex_Equals_Zero_And_Length_Equals_Input_Length_Then_Result_Equals_Input()
+        {
+            var str = "abcd";
+            var substr = UnicodeHelper.SubstringByTextElements(str, 0, str.Length);
+            Assert.AreEqual(str, substr);
+        }
+
+        [TestMethod]
+        public void When_StartIndex_Equals_Zero_And_Length_Is_GreaterThan_InputLength_Then_Result_Equals_Input()
+        {
+            var str = "abcd";
+            var substr = UnicodeHelper.SubstringByTextElements(str, 0, str.Length + 1);
+            Assert.AreEqual(str, substr);
+        }
+
+        [TestMethod]
+        public void When_StartIndex_GreaterThan_Zero_And_Length_LessThan_Input_Length_Then_Result_Contains_Part_Of_Input()
+        {
+            var str = "abcd";
+            var substr = UnicodeHelper.SubstringByTextElements(str, 1, 2);
+            Assert.AreEqual("bc", substr);
+        }
+
+        [TestMethod]
+        public void When_StartIndex_Equals_Zero_And_Length_LessThan_InputLength_Then_Result_Does_Not_Include_End_Of_Input()
+        {
             var str = "What better way to celebrate Christmas than supporting your team in the Greg Shupe Christmas tourney @ Kent! (We play where it says 1)🎅🏼⛄️🎅🏼 https://t.co/oUeMIkyb5G";
 
-            // Act
-            var substr = UnicodeHelper.UnicodeSubstring(str, 141);
+            var substr = UnicodeHelper.SubstringByTextElements(str, 0, 140);
 
-            // Assert
-            Assert.AreEqual(substr, "https://t.co/oUeMIkyb5G");
+            var expectedSubstr = "What better way to celebrate Christmas than supporting your team in the Greg Shupe Christmas tourney @ Kent! (We play where it says 1)🎅🏼⛄️🎅🏼 ";
+            Assert.AreEqual(expectedSubstr, substr);
+        }
+
+        [TestMethod]
+        public void When_StartIndex_GreaterThan_Zero_And_Length_LessThan_InputLength_Then_Result_Does_Not_Include_Beginning_Or_End_Of_Input()
+        {
+            var str = "@sam @aileen Check out this photo of @YellowstoneNPS! It makes me want to go camping there this summer. Have you visited before?? nps.gov/yell/index.htm pic.twitter.com/e8bDiL6LI4";
+
+            var substr = UnicodeHelper.SubstringByTextElements(str, 13, 140);
+
+            var expectedSubstr = "Check out this photo of @YellowstoneNPS! It makes me want to go camping there this summer. Have you visited before?? nps.gov/yell/index.htm ";
+            Assert.AreEqual(expectedSubstr, substr);
         }
     }
 }

--- a/Testinvi/Tweetinvi.Logic/ExtendedTweetTests.cs
+++ b/Testinvi/Tweetinvi.Logic/ExtendedTweetTests.cs
@@ -64,10 +64,10 @@ namespace Testinvi.Tweetinvi.Core
 
             Assert.AreEqual(tweet.Prefix, "@sam @aileen ");
             Assert.AreEqual(tweet.Prefix.Length, 13);
-            Assert.AreEqual(tweet.Text, "Check out this photo of @YellowstoneNPS! It makes me want to go camping there this summer. Have you visited before?? nps.gov/yell/index.htm ");
-            Assert.AreEqual(tweet.Text.Length, 140);
-            Assert.AreEqual(tweet.Suffix, "pic.twitter.com/e8bDiL6LI4");
-            Assert.AreEqual(tweet.Suffix.Length, 26);
+            Assert.AreEqual(tweet.Text, "Check out this photo of @YellowstoneNPS! It makes me want to go camping there this summer. Have you visited before?? nps.gov/yell/index.htm");
+            Assert.AreEqual(tweet.Text.Length, 139);
+            Assert.AreEqual(tweet.Suffix, " pic.twitter.com/e8bDiL6LI4");
+            Assert.AreEqual(tweet.Suffix.Length, 27);
         }
 
         [TestMethod]
@@ -86,8 +86,8 @@ namespace Testinvi.Tweetinvi.Core
             var tweet = InitTweet(_fullTextTweetWith1Mention, TweetMode.Extended);
 
             Assert.AreEqual(tweet.Prefix, "@jeremycloud ");
-            Assert.AreEqual(tweet.Text, "Who would win in a battle between a Barred Owl and a Cooper`s Hawk? ");
-            Assert.AreEqual(tweet.Suffix, "https://t.co/FamikDro2h");
+            Assert.AreEqual(tweet.Text, "Who would win in a battle between a Barred Owl and a Cooper`s Hawk?");
+            Assert.AreEqual(tweet.Suffix, " https://t.co/FamikDro2h");
         }
 
         [TestMethod]
@@ -199,13 +199,15 @@ namespace Testinvi.Tweetinvi.Core
         }
 
         [TestMethod]
-        public void UnicodeExtendedTweetSuffix()
+        public void ExtendedTweetContainingUnicode()
         {
             ITweet tweet = InitTweet(EXTENDED_TWEET_WITH_UNICODE, TweetMode.Extended);
 
+            Assert.AreEqual(tweet.FullText, "What better way to celebrate Christmas than supporting your team in the Greg Shupe Christmas tourney @ Kent! (We play where it says 1)🎅🏼⛄️🎅🏼 https://t.co/oUeMIkyb5G");
+            Assert.AreEqual(tweet.Prefix, "");
+            Assert.AreEqual(tweet.Text, "What better way to celebrate Christmas than supporting your team in the Greg Shupe Christmas tourney @ Kent! (We play where it says 1)🎅🏼⛄️🎅🏼 ");
             Assert.AreEqual(tweet.Suffix, "https://t.co/oUeMIkyb5G");
         }
-
 
         private static ITweet InitTweet(string text, TweetMode? tweetMode)
         {

--- a/Tweetinvi.Core/Core/Helpers/UnicodeHelper.cs
+++ b/Tweetinvi.Core/Core/Helpers/UnicodeHelper.cs
@@ -6,72 +6,36 @@ namespace Tweetinvi.Core.Core.Helpers
 {
     public static class UnicodeHelper
     {
-        public static string UnicodeSubstring(string str, int startIndex)
+        // Some versions of the .Net framework have this functionality built in
+        // See StringInfo.SubstringByTextElements()
+        public static string SubstringByTextElements(string str, int startingTextElement)
+        {
+            return SubstringByTextElements(str, startingTextElement, str?.Length ?? 0);
+        }
+
+        public static string SubstringByTextElements(string str, int startingTextElement, int lengthInTextElements)
         {
             if (str == null)
             {
                 return null;
             }
 
-            var sbuilder = new StringBuilder();
-
-            Func<string, int, bool> shouldCountTwice = (string str2, int i2) =>
-            {
-                if (char.IsSurrogatePair(str2, i2))
-                {
-                    var grapheme = $"{str2[i2]}{str2[i2 + 1]}";
-
-                    UnicodeCategory characterChategory = CharUnicodeInfo.GetUnicodeCategory(grapheme, 0);
-
-                    return characterChategory == UnicodeCategory.ModifierSymbol;
-                }
-
-                return false;
-            };
-
+            var textElements = StringInfo.GetTextElementEnumerator(str);
+            var substr = new StringBuilder();
+            var substrElementCount = 0;
             var i = 0;
-            for (; i < startIndex; ++i)
+
+            while (textElements.MoveNext())
             {
-                if (char.IsSurrogatePair(str, i))
+                if (i >= startingTextElement && substrElementCount < lengthInTextElements)
                 {
-                    ++i;
-                    ++startIndex;
-
-                    var grapheme = $"{str[i]}{str[i + 1]}";
-
-                    UnicodeCategory characterChategory = CharUnicodeInfo.GetUnicodeCategory(grapheme, 0);
-
-                    if (characterChategory == UnicodeCategory.ModifierSymbol)
-                    {
-                        ++startIndex;
-                    }
+                    substr.Append(textElements.GetTextElement());
+                    substrElementCount++;
                 }
+                i++;
             }
 
-            for (int j = 0; i + j < str.Length; ++j)
-            {
-                if (char.IsSurrogatePair(str, i + j))
-                {
-                    var grapheme = $"{str[i + j]}{str[i + j + 1]}";
-
-                    UnicodeCategory characterChategory = CharUnicodeInfo.GetUnicodeCategory(grapheme, 0);
-
-                    ++j;
-
-                    if (characterChategory == UnicodeCategory.ModifierSymbol)
-                    {
-                        continue;
-                    }
-
-                    sbuilder.Append(grapheme);
-                }
-                else
-                {
-                    sbuilder.Append(str[i + j]);
-                }
-            }
-
-            return sbuilder.ToString();
+            return substr.ToString();
         }
 
         public static bool AnyUnicode(string str)
@@ -92,14 +56,7 @@ namespace Tweetinvi.Core.Core.Helpers
         /// </summary>
         public static int UTF32Length(this string str)
         {
-            var length = 0;
-
-            for (var i = 0; i < str.Length; i += char.IsSurrogatePair(str, i) ? 2 : 1)
-            {
-                ++length;
-            }
-
-            return length;
+            return new StringInfo(str).LengthInTextElements;
         }
     }
 }

--- a/Tweetinvi.Logic/Tweet.cs
+++ b/Tweetinvi.Logic/Tweet.cs
@@ -83,12 +83,7 @@ namespace Tweetinvi.Logic
                 var contentStartIndex = DisplayTextRange[0];
                 var contentEndIndex = DisplayTextRange[1];
 
-                if (contentEndIndex < _tweetDTO.FullText.Length)
-                {
-                    ++contentEndIndex;
-                }
-
-                return _tweetDTO.FullText.Substring(contentStartIndex, contentEndIndex - contentStartIndex);
+                return UnicodeHelper.SubstringByTextElements(_tweetDTO.FullText, contentStartIndex, contentEndIndex - contentStartIndex);
             }
             set { _tweetDTO.Text = value; }
         }
@@ -118,13 +113,7 @@ namespace Tweetinvi.Logic
                 if (text != null && DisplayTextRange != null)
                 {
                     var suffixStartIndex = DisplayTextRange[1];
-
-                    if (suffixStartIndex < text.Length && suffixStartIndex > 0)
-                    {
-                        ++suffixStartIndex;
-                    }
-
-                    return UnicodeHelper.UnicodeSubstring(text, suffixStartIndex);
+                    return UnicodeHelper.SubstringByTextElements(text, suffixStartIndex);
                 }
 
                 return null;


### PR DESCRIPTION
This addresses Issue #430 by changing the way Unicode characters are counted. It prevents the extended tweet Text and Suffix properties from splitting in the middle of a multi-byte character. This uses built-in .Net functionality to count Unicode characters. Some existing unit tests needed minor updates.