### PR TITLE
#652 - Encoding query parameters to allow comma, hash etc.

### DIFF
--- a/Tweetinvi.Controllers/Account/AccountQueryGenerator.cs
+++ b/Tweetinvi.Controllers/Account/AccountQueryGenerator.cs
@@ -93,10 +93,10 @@ namespace Tweetinvi.Controllers.Account
         {
             var query = new StringBuilder(Resources.Account_UpdateProfile);
 
-            query.AddParameterToQuery("name", parameters.Name);
-            query.AddParameterToQuery("url", parameters.Url);
-            query.AddParameterToQuery("location", parameters.Location);
-            query.AddParameterToQuery("description", parameters.Description);
+            query.AddParameterToQuery("name", Uri.EscapeDataString(parameters.Name));
+            query.AddParameterToQuery("url", Uri.EscapeDataString(parameters.Url));
+            query.AddParameterToQuery("location", Uri.EscapeDataString(parameters.Location));
+            query.AddParameterToQuery("description", Uri.EscapeDataString(parameters.Description));
             query.AddParameterToQuery("profile_link_color", parameters.ProfileLinkColor);
             query.AddParameterToQuery("include_entities", parameters.IncludeEntities);
             query.AddParameterToQuery("skip_status", parameters.SkipStatus);


### PR DESCRIPTION
Original issue mentioned only about description but since there could be special characters in name, location and url which can break the request URL, I'm including the fix to those as well.