### PR TITLE
fix URL encoding of geocode for a search

### DIFF
--- a/Tweetinvi.Controllers/Properties/Resources.cs
+++ b/Tweetinvi.Controllers/Properties/Resources.cs
@@ -355,9 +355,9 @@ namespace Tweetinvi.Controllers.Properties
         public static string Search_SearchUsers = "https://api.twitter.com/1.1/users/search.json";
 
         /// <summary>
-        ///   Looks up a localized string similar to {0}%2C{1}%2C{2}{3}.
+        ///   Looks up a localized string similar to {0},{1},{2}{3}.
         /// </summary>
-        public static string SearchParameter_GeoCode = "{0}%2C{1}%2C{2}{3}";
+        public static string SearchParameter_GeoCode = "{0},{1},{2}{3}";
 
         /// <summary>
         ///   Looks up a localized string similar to &amp;lang={0}.


### PR DESCRIPTION
Use "," rather than the URL encoded version as the string gets URL encoded later.