### PR TITLE
Fix #737 - Waiting for new rate limit allocation

### DIFF
--- a/Tweetinvi.Controllers/Friendship/FriendshipController.cs
+++ b/Tweetinvi.Controllers/Friendship/FriendshipController.cs
@@ -36,24 +36,24 @@ namespace Tweetinvi.Controllers.Friendship
         }
 
         // Get Users Requesting Friendship
-        public IEnumerable<long> GetUserIdsRequestingFriendship(int maximumUserIdsToRetrieve = 75000)
+        public IEnumerable<long> GetUserIdsRequestingFriendship(int maximumUserIdsToRetrieve = TweetinviConsts.FRIENDSHIPS_INCOMING_IDS_MAX_PER_REQ)
         {
             return _friendshipQueryExecutor.GetUserIdsRequestingFriendship(maximumUserIdsToRetrieve);
         }
 
-        public IEnumerable<IUser> GetUsersRequestingFriendship(int maximumUsersToRetrieve = 75000)
+        public IEnumerable<IUser> GetUsersRequestingFriendship(int maximumUsersToRetrieve = TweetinviConsts.FRIENDSHIPS_INCOMING_USERS_MAX_PER_REQ)
         {
             var userIds = GetUserIdsRequestingFriendship(maximumUsersToRetrieve);
             return _userFactory.GetUsersFromIds(userIds);
         }
 
         // Get Users You requested to follow
-        public IEnumerable<long> GetUserIdsYouRequestedToFollow(int maximumUsersToRetrieve = 75000)
+        public IEnumerable<long> GetUserIdsYouRequestedToFollow(int maximumUsersToRetrieve = TweetinviConsts.FRIENDSHIPS_OUTGOING_IDS_MAX_PER_REQ)
         {
             return _friendshipQueryExecutor.GetUserIdsYouRequestedToFollow(maximumUsersToRetrieve);
         }
 
-        public IEnumerable<IUser> GetUsersYouRequestedToFollow(int maximumUsersToRetrieve = 75000)
+        public IEnumerable<IUser> GetUsersYouRequestedToFollow(int maximumUsersToRetrieve = TweetinviConsts.FRIENDSHIPS_OUTGOING_USERS_MAX_PER_REQ)
         {
             var userIds = GetUserIdsYouRequestedToFollow(maximumUsersToRetrieve);
             return _userFactory.GetUsersFromIds(userIds);

--- a/Tweetinvi.Controllers/Friendship/FriendshipController.cs
+++ b/Tweetinvi.Controllers/Friendship/FriendshipController.cs
@@ -105,21 +105,21 @@ namespace Tweetinvi.Controllers.Friendship
         }
 
         // Update Friendship Authorizations
-       public bool UpdateRelationshipAuthorizationsWith(IUserIdentifier user, bool retweetsEnabled, bool deviceNotifictionEnabled)
+       public bool UpdateRelationshipAuthorizationsWith(IUserIdentifier user, bool retweetsEnabled, bool deviceNotificationEnabled)
         {
-            var friendshipAuthorizations = _friendshipFactory.GenerateFriendshipAuthorizations(retweetsEnabled, deviceNotifictionEnabled);
+            var friendshipAuthorizations = _friendshipFactory.GenerateFriendshipAuthorizations(retweetsEnabled, deviceNotificationEnabled);
             return _friendshipQueryExecutor.UpdateRelationshipAuthorizationsWith(user, friendshipAuthorizations);
         }
 
-        public bool UpdateRelationshipAuthorizationsWith(long userId, bool retweetsEnabled, bool deviceNotifictionEnabled)
+        public bool UpdateRelationshipAuthorizationsWith(long userId, bool retweetsEnabled, bool deviceNotificationEnabled)
         {
-            var friendshipAuthorizations = _friendshipFactory.GenerateFriendshipAuthorizations(retweetsEnabled, deviceNotifictionEnabled);
+            var friendshipAuthorizations = _friendshipFactory.GenerateFriendshipAuthorizations(retweetsEnabled, deviceNotificationEnabled);
             return _friendshipQueryExecutor.UpdateRelationshipAuthorizationsWith(new UserIdentifier(userId), friendshipAuthorizations);
         }
 
-        public bool UpdateRelationshipAuthorizationsWith(string userScreenName, bool retweetsEnabled, bool deviceNotifictionEnabled)
+        public bool UpdateRelationshipAuthorizationsWith(string userScreenName, bool retweetsEnabled, bool deviceNotificationEnabled)
         {
-            var friendshipAuthorizations = _friendshipFactory.GenerateFriendshipAuthorizations(retweetsEnabled, deviceNotifictionEnabled);
+            var friendshipAuthorizations = _friendshipFactory.GenerateFriendshipAuthorizations(retweetsEnabled, deviceNotificationEnabled);
             return _friendshipQueryExecutor.UpdateRelationshipAuthorizationsWith(new UserIdentifier(userScreenName), friendshipAuthorizations);
         }
 

--- a/Tweetinvi.Core/Core/Controllers/IFriendshipController.cs
+++ b/Tweetinvi.Core/Core/Controllers/IFriendshipController.cs
@@ -5,11 +5,15 @@ namespace Tweetinvi.Core.Controllers
 {
     public interface IFriendshipController
     {
-        IEnumerable<long> GetUserIdsRequestingFriendship(int maximumUserIdsToRetrieve = 75000);
-        IEnumerable<IUser> GetUsersRequestingFriendship(int maximumUsersToRetrieve = 75000);
+        IEnumerable<long> GetUserIdsRequestingFriendship(
+            int maximumUserIdsToRetrieve = TweetinviConsts.FRIENDSHIPS_INCOMING_IDS_MAX_PER_REQ);
+        IEnumerable<IUser> GetUsersRequestingFriendship(
+            int maximumUsersToRetrieve = TweetinviConsts.FRIENDSHIPS_INCOMING_USERS_MAX_PER_REQ);
 
-        IEnumerable<long> GetUserIdsYouRequestedToFollow(int maximumUsersToRetrieve = 75000);
-        IEnumerable<IUser> GetUsersYouRequestedToFollow(int maximumUsersToRetrieve = 75000);
+        IEnumerable<long> GetUserIdsYouRequestedToFollow(
+            int maximumUsersToRetrieve = TweetinviConsts.FRIENDSHIPS_OUTGOING_IDS_MAX_PER_REQ);
+        IEnumerable<IUser> GetUsersYouRequestedToFollow(
+            int maximumUsersToRetrieve = TweetinviConsts.FRIENDSHIPS_OUTGOING_USERS_MAX_PER_REQ);
 
         // Create Friendship with
         bool CreateFriendshipWith(IUserIdentifier user);

--- a/Tweetinvi.Core/Core/Controllers/IFriendshipController.cs
+++ b/Tweetinvi.Core/Core/Controllers/IFriendshipController.cs
@@ -22,9 +22,9 @@ namespace Tweetinvi.Core.Controllers
         bool DestroyFriendshipWith(string userScreeName);
 
         // Update Friendship Authorizations
-        bool UpdateRelationshipAuthorizationsWith(IUserIdentifier user, bool retweetsEnabled, bool deviceNotifictionEnabled);
-        bool UpdateRelationshipAuthorizationsWith(long userId, bool retweetsEnabled, bool deviceNotifictionEnabled);
-        bool UpdateRelationshipAuthorizationsWith(string userScreenName, bool retweetsEnabled, bool deviceNotifictionEnabled);
+        bool UpdateRelationshipAuthorizationsWith(IUserIdentifier user, bool retweetsEnabled, bool deviceNotificationEnabled);
+        bool UpdateRelationshipAuthorizationsWith(long userId, bool retweetsEnabled, bool deviceNotificationEnabled);
+        bool UpdateRelationshipAuthorizationsWith(string userScreenName, bool retweetsEnabled, bool deviceNotificationEnabled);
 
         // Relationship
         IRelationshipDetails GetRelationshipBetween(IUserIdentifier sourceUserIdentifier, IUserIdentifier targetUserIdentifier);

--- a/Tweetinvi.Core/Core/Models/Async/IAuthenticatedUserAsync.cs
+++ b/Tweetinvi.Core/Core/Models/Async/IAuthenticatedUserAsync.cs
@@ -68,12 +68,14 @@ namespace Tweetinvi.Core.Models.Async
         /// <summary>
         /// Get the users who requested to follow you.
         /// </summary>
-        Task<IEnumerable<IUser>> GetUsersRequestingFriendshipAsync(int maximumUserIdsToRetrieve = 75000);
+        Task<IEnumerable<IUser>> GetUsersRequestingFriendshipAsync(
+            int maximumUserIdsToRetrieve = TweetinviConsts.FRIENDSHIPS_INCOMING_USERS_MAX_PER_REQ);
 
         /// <summary>
         /// Get the users you've requested to follow.
         /// </summary>
-        Task<IEnumerable<IUser>> GetUsersYouRequestedToFollowAsync(int maximumUsersToRetrieve = 75000);
+        Task<IEnumerable<IUser>> GetUsersYouRequestedToFollowAsync(
+            int maximumUsersToRetrieve = TweetinviConsts.FRIENDSHIPS_OUTGOING_USERS_MAX_PER_REQ);
 
         /// <summary>
         /// Folow a specific user.

--- a/Tweetinvi.Core/Core/TweetinviSettingsAccessor.cs
+++ b/Tweetinvi.Core/Core/TweetinviSettingsAccessor.cs
@@ -37,6 +37,13 @@ namespace Tweetinvi.Core
         /// Solution used to track the rate limits in the current thread.
         /// </summary>
         RateLimitTrackerMode RateLimitTrackerMode { get; set; }
+
+        /// <summary>
+        /// How much additional time to wait than should be strictly necessary for a new batch of Twitter rate limits
+        /// to be available. Required to account for timing discrepancies both within Twitter's servers and between
+        /// Twitter and us. 
+        /// </summary>
+        int RateLimitWaitFudgeMs { get; set; }
     }
 
     public class TweetinviSettingsAccessor : ITweetinviSettingsAccessor
@@ -48,6 +55,7 @@ namespace Tweetinvi.Core
             var threadSettings = TweetinviCoreModule.TweetinviContainer.Resolve<ITweetinviSettings>();
             threadSettings.HttpRequestTimeout = 10000;
             threadSettings.UploadTimeout = 60000;
+            threadSettings.RateLimitWaitFudgeMs = 5000;
 
             CurrentThreadSettings = threadSettings;
         }
@@ -123,6 +131,12 @@ namespace Tweetinvi.Core
         {
             get { return CurrentThreadSettings.RateLimitTrackerMode; }
             set { CurrentThreadSettings.RateLimitTrackerMode = value; }
+        }
+
+        public int RateLimitWaitFudgeMs
+        {
+            get => CurrentThreadSettings.RateLimitWaitFudgeMs;
+            set => CurrentThreadSettings.RateLimitWaitFudgeMs = value;
         }
     }
 }

--- a/Tweetinvi.Core/Public/Settings/TweetinviSettings.cs
+++ b/Tweetinvi.Core/Public/Settings/TweetinviSettings.cs
@@ -58,6 +58,13 @@ namespace Tweetinvi
         RateLimitTrackerMode RateLimitTrackerMode { get; set; }
 
         /// <summary>
+        /// How much additional time to wait than should be strictly necessary for a new batch of Twitter rate limits
+        /// to be available. Required to account for timing discrepancies both within Twitter's servers and between
+        /// Twitter and us. 
+        /// </summary>
+        int RateLimitWaitFudgeMs { get; set; }
+
+        /// <summary>
         /// Specify whether you want your tweet to use the extended mode.
         /// </summary>
         TweetMode TweetMode { get; set; }
@@ -86,6 +93,7 @@ namespace Tweetinvi
         public IProxyConfig ProxyConfig { get; set; }
         public int HttpRequestTimeout { get; set; }
         public RateLimitTrackerMode RateLimitTrackerMode { get; set; }
+        public int RateLimitWaitFudgeMs { get; set; }
         public TweetMode TweetMode { get; set; }
         public int UploadTimeout { get; set; }
         public Func<DateTime> GetUtcDateTime { get; set; }
@@ -103,6 +111,7 @@ namespace Tweetinvi
             clone.HttpRequestTimeout = HttpRequestTimeout;
             clone.UploadTimeout = UploadTimeout;
             clone.RateLimitTrackerMode = RateLimitTrackerMode;
+            clone.RateLimitWaitFudgeMs = RateLimitWaitFudgeMs;
             clone.TweetMode = TweetMode;
             clone.GetUtcDateTime = GetUtcDateTime;
 
@@ -115,6 +124,7 @@ namespace Tweetinvi
             HttpRequestTimeout = other.HttpRequestTimeout;
             UploadTimeout = other.UploadTimeout;
             RateLimitTrackerMode = other.RateLimitTrackerMode;
+            RateLimitWaitFudgeMs = other.RateLimitWaitFudgeMs;
             TweetMode = other.TweetMode;
             GetUtcDateTime = other.GetUtcDateTime;
         }

--- a/Tweetinvi.Core/Public/TweetinviConsts.cs
+++ b/Tweetinvi.Core/Public/TweetinviConsts.cs
@@ -67,5 +67,21 @@
         public const int MESSAGE_QUICK_REPLY_LABEL_MAX_LENGTH = 36;
         public const int MESSAGE_QUICK_REPLY_DESCRIPTION_MAX_LENGTH = 72;
         public const int MESSAGE_QUICK_REPLY_METADATA_MAX_LENGTH = 1000;
+
+        // https://developer.twitter.com/en/docs/accounts-and-users/follow-search-get-users/api-reference/get-users-lookup
+        public const int USERS_LOOKUP_MAX_PER_REQ = 100;
+
+        // https://developer.twitter.com/en/docs/accounts-and-users/follow-search-get-users/api-reference/get-friends-ids.html
+        public const int FRIENDSHIPS_INCOMING_IDS_MAX_PER_REQ = 5000;
+
+        // https://developer.twitter.com/en/docs/accounts-and-users/follow-search-get-users/api-reference/get-friendships-outgoing
+        public const int FRIENDSHIPS_OUTGOING_IDS_MAX_PER_REQ = 5000;
+
+        // Request to get User objects for incoming/outgoing friendship requests requires a request to get the IDs,
+        //  and then a request to get the User objects for those IDs.
+        // Min: USERS_LOOKUP_MAX_PER_REQ, FRIENDSHIPS_INCOMING_IDS_MAX_PER_REQ
+        public const int FRIENDSHIPS_INCOMING_USERS_MAX_PER_REQ = USERS_LOOKUP_MAX_PER_REQ;
+        // Min: USERS_LOOKUP_MAX_PER_REQ, FRIENDSHIPS_OUTGOING_IDS_MAX_PER_REQ
+        public const int FRIENDSHIPS_OUTGOING_USERS_MAX_PER_REQ = USERS_LOOKUP_MAX_PER_REQ;
     }
 }

--- a/Tweetinvi.Factories/User/UserFactoryQueryExecutor.cs
+++ b/Tweetinvi.Factories/User/UserFactoryQueryExecutor.cs
@@ -26,8 +26,6 @@ namespace Tweetinvi.Factories.User
 
     public class UserFactoryQueryExecutor : IUserFactoryQueryExecutor
     {
-        private const int MAX_LOOKUP_USERS = 100;
-
         private readonly ITwitterAccessor _twitterAccessor;
         private readonly IUserQueryParameterGenerator _userQueryParameterGenerator;
 
@@ -57,13 +55,16 @@ namespace Tweetinvi.Factories.User
         }
 
         // Get Multiple users
-        public List<IUserDTO> GetUsersDTOFromIds(IEnumerable<long> userIds)
+        public List<IUserDTO> GetUsersDTOFromIds(IEnumerable<long> enumerableUserIds)
         {
+            // Optimisation: prevent multiple enumerations
+            long[] userIds = enumerableUserIds as long[] ?? enumerableUserIds.ToArray();
+
             var usersDTO = new List<IUserDTO>();
 
-            for (int i = 0; i < userIds.Count(); i += MAX_LOOKUP_USERS)
+            for (int i = 0; i < userIds.Length; i += TweetinviConsts.USERS_LOOKUP_MAX_PER_REQ)
             {
-                var userIdsToLookup = userIds.Skip(i).Take(MAX_LOOKUP_USERS).ToList();
+                var userIdsToLookup = userIds.Skip(i).Take(TweetinviConsts.USERS_LOOKUP_MAX_PER_REQ).ToList();
                 var retrievedUsers = LookupUserIds(userIdsToLookup);
                 usersDTO.AddRangeSafely(retrievedUsers);
 
@@ -76,13 +77,16 @@ namespace Tweetinvi.Factories.User
             return usersDTO;
         }
 
-        public List<IUserDTO> GetUsersDTOFromScreenNames(IEnumerable<string> userScreenNames)
+        public List<IUserDTO> GetUsersDTOFromScreenNames(IEnumerable<string> enumerableUserScreenNames)
         {
+            // Optimisation: prevent multiple enumerations
+            string[] userScreenNames = enumerableUserScreenNames as string[] ?? enumerableUserScreenNames.ToArray();
+
             var usersDTO = new List<IUserDTO>();
 
-            for (int i = 0; i < userScreenNames.Count(); i += MAX_LOOKUP_USERS)
+            for (int i = 0; i < userScreenNames.Length; i += TweetinviConsts.USERS_LOOKUP_MAX_PER_REQ)
             {
-                var userScreenNamesToLookup = userScreenNames.Skip(i).Take(MAX_LOOKUP_USERS).ToList();
+                var userScreenNamesToLookup = userScreenNames.Skip(i).Take(TweetinviConsts.USERS_LOOKUP_MAX_PER_REQ).ToList();
                 var retrievedUsers = LookupUserScreenNames(userScreenNamesToLookup);
                 usersDTO.AddRangeSafely(retrievedUsers);
 
@@ -98,7 +102,7 @@ namespace Tweetinvi.Factories.User
         // Lookup
         public List<IUserDTO> LookupUserIds(List<long> userIds)
         {
-            if (userIds.Count > MAX_LOOKUP_USERS)
+            if (userIds.Count > TweetinviConsts.USERS_LOOKUP_MAX_PER_REQ)
             {
                 throw new InvalidOperationException("Cannot retrieve that quantity of users at once");
             }
@@ -111,7 +115,7 @@ namespace Tweetinvi.Factories.User
 
         public List<IUserDTO> LookupUserScreenNames(List<string> userName)
         {
-            if (userName.Count > MAX_LOOKUP_USERS)
+            if (userName.Count > TweetinviConsts.USERS_LOOKUP_MAX_PER_REQ)
             {
                 throw new InvalidOperationException("Cannot retrieve that quantity of users at once");
             }

--- a/Tweetinvi.Logic/AuthenticatedUser.cs
+++ b/Tweetinvi.Logic/AuthenticatedUser.cs
@@ -142,12 +142,14 @@ namespace Tweetinvi.Logic
         }
 
         // Friends - Followers
-        public IEnumerable<IUser> GetUsersRequestingFriendship(int maximumUserIdsToRetrieve = 75000)
+        public IEnumerable<IUser> GetUsersRequestingFriendship(
+            int maximumUserIdsToRetrieve = TweetinviConsts.FRIENDSHIPS_INCOMING_USERS_MAX_PER_REQ)
         {
             return ExecuteAuthenticatedUserOperation(() => _friendshipController.GetUsersRequestingFriendship(maximumUserIdsToRetrieve));
         }
 
-        public IEnumerable<IUser> GetUsersYouRequestedToFollow(int maximumUserIdsToRetrieve = 75000)
+        public IEnumerable<IUser> GetUsersYouRequestedToFollow(
+            int maximumUserIdsToRetrieve = TweetinviConsts.FRIENDSHIPS_OUTGOING_USERS_MAX_PER_REQ)
         {
             return ExecuteAuthenticatedUserOperation(() => _friendshipController.GetUsersYouRequestedToFollow(maximumUserIdsToRetrieve));
         }
@@ -468,15 +470,19 @@ namespace Tweetinvi.Logic
             return await ExecuteAuthenticatedUserOperation(() => _taskFactory.ExecuteTaskAsync(() => UpdateRelationshipAuthorizationsWith(screenName, retweetsEnabled, deviceNotificationsEnabled)));
         }
 
-        
-        public async Task<IEnumerable<IUser>> GetUsersRequestingFriendshipAsync(int maximumUserIdsToRetrieve = 75000)
+
+        public async Task<IEnumerable<IUser>> GetUsersRequestingFriendshipAsync(
+            int maximumUserIdsToRetrieve = TweetinviConsts.FRIENDSHIPS_INCOMING_USERS_MAX_PER_REQ)
         {
-            return await ExecuteAuthenticatedUserOperation(() => _taskFactory.ExecuteTaskAsync(() => GetUsersRequestingFriendship(maximumUserIdsToRetrieve)));
+            return await ExecuteAuthenticatedUserOperation(() =>
+                _taskFactory.ExecuteTaskAsync(() => GetUsersRequestingFriendship(maximumUserIdsToRetrieve)));
         }
 
-        public async Task<IEnumerable<IUser>> GetUsersYouRequestedToFollowAsync(int maximumUsersToRetrieve = 75000)
+        public async Task<IEnumerable<IUser>> GetUsersYouRequestedToFollowAsync(
+            int maximumUsersToRetrieve = TweetinviConsts.FRIENDSHIPS_OUTGOING_USERS_MAX_PER_REQ)
         {
-            return await ExecuteAuthenticatedUserOperation(() => _taskFactory.ExecuteTaskAsync(() => GetUsersYouRequestedToFollow(maximumUsersToRetrieve)));
+            return await ExecuteAuthenticatedUserOperation(() =>
+                _taskFactory.ExecuteTaskAsync(() => GetUsersYouRequestedToFollow(maximumUsersToRetrieve)));
         }
 
         public async Task<bool> FollowUserAsync(IUserIdentifier user)

--- a/Tweetinvi/Account.cs
+++ b/Tweetinvi/Account.cs
@@ -273,7 +273,8 @@ namespace Tweetinvi
         /// <summary>
         /// Get the ids of the users who want to follow you.
         /// </summary>
-        public static IEnumerable<long> GetUserIdsRequestingFriendship(int maximumUserIdsToRetrieve = 75000)
+        public static IEnumerable<long> GetUserIdsRequestingFriendship(
+            int maximumUserIdsToRetrieve = TweetinviConsts.FRIENDSHIPS_INCOMING_IDS_MAX_PER_REQ)
         {
             return FriendshipController.GetUserIdsRequestingFriendship(maximumUserIdsToRetrieve);
         }
@@ -281,7 +282,8 @@ namespace Tweetinvi
         /// <summary>
         /// Get the users who want to follow you.
         /// </summary>
-        public static IEnumerable<IUser> GetUsersRequestingFriendship(int maximumUserIdsToRetrieve = 75000)
+        public static IEnumerable<IUser> GetUsersRequestingFriendship(
+            int maximumUserIdsToRetrieve = TweetinviConsts.FRIENDSHIPS_INCOMING_USERS_MAX_PER_REQ)
         {
             return FriendshipController.GetUsersRequestingFriendship(maximumUserIdsToRetrieve);
         }
@@ -289,7 +291,7 @@ namespace Tweetinvi
         /// <summary>
         /// Get the user ids of the people you requested to follow.
         /// </summary>
-        public static IEnumerable<long> GetUserIdsYouRequestedToFollow(int maximumUserIdsToRetrieve = 75000)
+        public static IEnumerable<long> GetUserIdsYouRequestedToFollow(int maximumUserIdsToRetrieve = TweetinviConsts.FRIENDSHIPS_OUTGOING_IDS_MAX_PER_REQ)
         {
             return FriendshipController.GetUserIdsYouRequestedToFollow(maximumUserIdsToRetrieve);
         }
@@ -297,7 +299,8 @@ namespace Tweetinvi
         /// <summary>
         /// Get the user ids of the people you requested to follow.
         /// </summary>
-        public static IEnumerable<IUser> GetUsersYouRequestedToFollow(int maximumUserIdsToRetrieve = 75000)
+        public static IEnumerable<IUser> GetUsersYouRequestedToFollow(
+            int maximumUserIdsToRetrieve = TweetinviConsts.FRIENDSHIPS_OUTGOING_USERS_MAX_PER_REQ)
         {
             return FriendshipController.GetUsersYouRequestedToFollow(maximumUserIdsToRetrieve);
         }

--- a/Tweetinvi/AccountAsync.cs
+++ b/Tweetinvi/AccountAsync.cs
@@ -83,22 +83,26 @@ namespace Tweetinvi
 
         #region Friendship
 
-        public static async Task<IEnumerable<long>> GetUserIdsRequestingFriendship(int maximumUserIdsToRetrieve = 75000)
+        public static async Task<IEnumerable<long>> GetUserIdsRequestingFriendship(
+            int maximumUserIdsToRetrieve = TweetinviConsts.FRIENDSHIPS_INCOMING_IDS_MAX_PER_REQ)
         {
             return await Sync.ExecuteTaskAsync(() => Account.GetUserIdsRequestingFriendship(maximumUserIdsToRetrieve));
         }
 
-        public static async Task<IEnumerable<IUser>> GetUsersRequestingFriendship(int maximumUserIdsToRetrieve = 75000)
+        public static async Task<IEnumerable<IUser>> GetUsersRequestingFriendship(
+            int maximumUserIdsToRetrieve = TweetinviConsts.FRIENDSHIPS_INCOMING_USERS_MAX_PER_REQ)
         {
             return await Sync.ExecuteTaskAsync(() => Account.GetUsersRequestingFriendship(maximumUserIdsToRetrieve));
         }
 
-        public static async Task<IEnumerable<long>> GetUserIdsYouRequestedToFollow(int maximumUserIdsToRetrieve = 75000)
+        public static async Task<IEnumerable<long>> GetUserIdsYouRequestedToFollow(
+            int maximumUserIdsToRetrieve = TweetinviConsts.FRIENDSHIPS_OUTGOING_IDS_MAX_PER_REQ)
         {
             return await Sync.ExecuteTaskAsync(() => Account.GetUserIdsYouRequestedToFollow(maximumUserIdsToRetrieve));
         }
 
-        public static async Task<IEnumerable<IUser>> GetUsersYouRequestedToFollow(int maximumUserIdsToRetrieve = 75000)
+        public static async Task<IEnumerable<IUser>> GetUsersYouRequestedToFollow(
+            int maximumUserIdsToRetrieve = TweetinviConsts.FRIENDSHIPS_OUTGOING_USERS_MAX_PER_REQ)
         {
             return await Sync.ExecuteTaskAsync(() => Account.GetUsersYouRequestedToFollow(maximumUserIdsToRetrieve));
         }


### PR DESCRIPTION
Replaces incorrect 75000 default values with the correct ones, and moves them all to constants.
Also, when tracking and waiting for new a new rate limit allocation, an additional wait has been added (default 5s) to ensure Twitter has given you your new rate limits.