### PR TITLE
Fix for error #799

### DIFF
--- a/Tweetinvi.Streams/Helpers/StreamTrackManager.cs
+++ b/Tweetinvi.Streams/Helpers/StreamTrackManager.cs
@@ -54,6 +54,8 @@ namespace Tweetinvi.Streams.Helpers
         // Twitter API Tracking
         public void AddTrack(string track, Action<T> trackReceived = null)
         {
+            if(track.IsEmpty()) return;
+            
             if (_tracks.Count < MaxTracks)
             {
                 string lowerTrack = track.ToLower();
@@ -254,7 +256,7 @@ namespace Tweetinvi.Streams.Helpers
                 var isMatching = true;
                 for (int j = 0; j < _tracksKeywordsArray[i].Length && isMatching; ++j)
                 {
-                    if (_tracksKeywordsArray[i][j][0] != '#' && _tracksKeywordsArray[i][j][0] != '$')
+                    if (_tracksKeywordsArray[i][j].Length >0 &&_tracksKeywordsArray[i][j][0] != '#' && _tracksKeywordsArray[i][j][0] != '$')
                     {
                         isMatching = matchingKeywords.Contains(_tracksKeywordsArray[i][j]) ||
                                      matchingKeywords.Contains(string.Format("#{0}", _tracksKeywordsArray[i][j])) ||


### PR DESCRIPTION
At the moment Tweetinvi tracked streams allows to add an empty string
as a tracked keyword. Because of this and exception is thrown that
cannot be handled in the parent application.
This is a small fix, first we ignore the empty strings when adding
tracked keywords, and we check for empty strings when searching for
matching Tracks.
See https://github.com/linvi/tweetinvi/issues/799