### PR TITLE
Activity API - Direct Message Structure Fix

### DIFF
--- a/Testinvi/Tweetinvi.Streams/AccountActivityStreamTests.cs
+++ b/Testinvi/Tweetinvi.Streams/AccountActivityStreamTests.cs
@@ -354,13 +354,7 @@ namespace Testinvi.Tweetinvi.Streams
 			            }
 		            }
 	            }],
-	            ""apps"": {
-		            ""13090192"": {
-			            ""id"": ""13090192"",
-			            ""name"": ""FuriousCamperTestApp1"",
-			            ""url"": ""https://twitter.com/furiouscamper""
-		            },
-		            ""users"": {},
+                ""users"": {
 		            ""3001969357"": {
 			            ""id"": ""3001969357"",
 			            ""created_timestamp"": ""1422556069340"",
@@ -407,6 +401,7 @@ namespace Testinvi.Tweetinvi.Streams
             Assert.AreEqual(eventsReceived.Count, 1);
             Assert.AreEqual(eventsReceived[0].Message.Text, "Hello World!");
             Assert.AreEqual(eventsReceived[0].Message.SenderId, 3001969357);
+            Assert.IsNull(eventsReceived[0].Message.App);
         }
 
         [TestMethod]
@@ -442,8 +437,9 @@ namespace Testinvi.Tweetinvi.Streams
 			            ""id"": ""13090192"",
 			            ""name"": ""FuriousCamperTestApp1"",
 			            ""url"": ""https://twitter.com/furiouscamper""
-		            },
-		            ""users"": {},
+		            }
+                },
+		        ""users"": {
 		            ""3001969357"": {
 			            ""id"": ""3001969357"",
 			            ""created_timestamp"": ""1422556069340"",

--- a/Tweetinvi.Streams/AccountActivityStream.cs
+++ b/Tweetinvi.Streams/AccountActivityStream.cs
@@ -228,7 +228,7 @@ namespace Tweetinvi.Streams
         private void TryRaiseMessageEvent(string eventName, JObject jsonObjectEvent)
         {
             var messageEventDTOs = jsonObjectEvent[eventName].ToObject<EventDTO[]>();
-            var apps = jsonObjectEvent["apps"].ToObject<Dictionary<string, App>>();
+            var apps = jsonObjectEvent["apps"]?.ToObject<Dictionary<string, App>>() ?? new Dictionary<string, App>();
 
             messageEventDTOs.ForEach(messageEventDTO =>
             {


### PR DESCRIPTION
Addresses #802 

updating to handle actual structure of direct message events for activity stream, twitter documentation is invalid and actual json received is different.  app data is not included for message sent events, but included for message received events