### PR TITLE
Fixed "lang" property for Tweet and User objects

### DIFF
--- a/Tweetinvi.Core/Public/Models/Interfaces/DTO/ITweetDTO.cs
+++ b/Tweetinvi.Core/Public/Models/Interfaces/DTO/ITweetDTO.cs
@@ -68,7 +68,7 @@ namespace Tweetinvi.Models.DTO
 
         ITweetDTO QuotedTweetDTO { get; set; }
 
-        Language Language { get; set; }
+        Language? Language { get; set; }
 
         bool PossiblySensitive { get; set; }
 

--- a/Tweetinvi.Core/Public/Models/Interfaces/DTO/IUserDTO.cs
+++ b/Tweetinvi.Core/Public/Models/Interfaces/DTO/IUserDTO.cs
@@ -20,7 +20,7 @@ namespace Tweetinvi.Models.DTO
 
         string Url { get; set; }
 
-        Language Language { get; set; }
+        Language? Language { get; set; }
 
         string Email { get; set; }
 

--- a/Tweetinvi.Core/Public/Models/Interfaces/ITweet.cs
+++ b/Tweetinvi.Core/Public/Models/Interfaces/ITweet.cs
@@ -155,7 +155,7 @@ namespace Tweetinvi.Models
         /// <summary>
         /// Main language used in the tweet
         /// </summary>
-        Language Language { get; }
+        Language? Language { get; }
 
         /// <summary>
         /// Geographic details concerning the location where the tweet has been published

--- a/Tweetinvi.Core/Public/Models/Interfaces/IUser.cs
+++ b/Tweetinvi.Core/Public/Models/Interfaces/IUser.cs
@@ -63,11 +63,6 @@ namespace Tweetinvi.Models
         string Url { get; }
 
         /// <summary>
-        /// Primary language of the user account.
-        /// </summary>
-        Language Language { get; }
-
-        /// <summary>
         /// Number of tweets (including retweets) the user published.
         /// </summary>
         int StatusesCount { get; }

--- a/Tweetinvi.Logic/DTO/TweetDTO.cs
+++ b/Tweetinvi.Logic/DTO/TweetDTO.cs
@@ -134,7 +134,7 @@ namespace Tweetinvi.Logic.DTO
 
         [JsonProperty("lang")]
         [JsonConverter(typeof(JsonPropertyConverterRepository))]
-        public Language Language { get; set; }
+        public Language? Language { get; set; }
 
         [JsonProperty("contributorsIds")]
         public int[] ContributorsIds { get; set; }

--- a/Tweetinvi.Logic/DTO/UserDTO.cs
+++ b/Tweetinvi.Logic/DTO/UserDTO.cs
@@ -37,7 +37,7 @@ namespace Tweetinvi.Logic.DTO
 
         [JsonProperty("lang")]
         [JsonConverter(typeof(JsonPropertyConverterRepository))]
-        public Language Language { get; set; }
+        public Language? Language { get; set; }
 
         [JsonProperty("email")]
         public string Email { get; set; }

--- a/Tweetinvi.Logic/JsonConverters/JsonLanguageConverter.cs
+++ b/Tweetinvi.Logic/JsonConverters/JsonLanguageConverter.cs
@@ -11,6 +11,11 @@ namespace Tweetinvi.Logic.JsonConverters
         {
             int parsed;
 
+            if (reader.Value == null && objectType == typeof(Language?))
+            {
+                return null;
+            }
+
             if (int.TryParse(reader.Value.ToString(), out parsed))
             {
                 return LanguageExtension.GetLangFromDescription(parsed);
@@ -26,7 +31,7 @@ namespace Tweetinvi.Logic.JsonConverters
 
         public override bool CanConvert(Type objectType)
         {
-            return objectType == typeof(Language);
+            return objectType == typeof(Language) || objectType == typeof(Language?);
         }
     }
 }

--- a/Tweetinvi.Logic/JsonConverters/JsonPropertyConverterRepository.cs
+++ b/Tweetinvi.Logic/JsonConverters/JsonPropertyConverterRepository.cs
@@ -64,6 +64,7 @@ namespace Tweetinvi.Logic.JsonConverters
             JsonConverters.Add(typeof(PrivacyMode), privacyModeConverter);
             JsonConverters.Add(typeof(ICoordinates), coordinatesConverter);
             JsonConverters.Add(typeof(Language), languageConverter);
+            JsonConverters.Add(typeof(Language?), languageConverter);
             JsonConverters.Add(typeof(AllowContributorRequestMode), allowContributorRequestConverter);
             JsonConverters.Add(typeof(AllowDirectMessagesFrom), allowDirectMessagesConverter);
             JsonConverters.Add(typeof(QuickReplyType), quickReplyTypeConverter);

--- a/Tweetinvi.Logic/Tweet.cs
+++ b/Tweetinvi.Logic/Tweet.cs
@@ -295,7 +295,7 @@ namespace Tweetinvi.Logic
             get { return _tweetDTO.PossiblySensitive; }
         }
 
-        public Language Language
+        public Language? Language
         {
             get { return _tweetDTO.Language; }
         }

--- a/Tweetinvi.Logic/User.cs
+++ b/Tweetinvi.Logic/User.cs
@@ -97,11 +97,6 @@ namespace Tweetinvi.Logic
             get { return _userDTO.Url; }
         }
 
-        public Language Language
-        {
-            get { return _userDTO.Language; }
-        }
-
         public int StatusesCount
         {
             get { return _userDTO.StatusesCount; }


### PR DESCRIPTION
On Tweet object the "lang" property is nullable (https://developer.twitter.com/en/docs/tweets/data-dictionary/overview/tweet-object)

On User object the "lang" property is deprecated (https://developer.twitter.com/en/docs/tweets/data-dictionary/overview/user-object.html)