### PR TITLE
Added a null check on apps tag.

### DIFF
--- a/Tweetinvi.Streams/AccountActivityStream.cs
+++ b/Tweetinvi.Streams/AccountActivityStream.cs
@@ -228,13 +228,13 @@ namespace Tweetinvi.Streams
         private void TryRaiseMessageEvent(string eventName, JObject jsonObjectEvent)
         {
             var messageEventDTOs = jsonObjectEvent[eventName].ToObject<EventDTO[]>();
-            var apps = jsonObjectEvent["apps"].ToObject<Dictionary<string, App>>();
+            var apps = jsonObjectEvent["apps"]?.ToObject<Dictionary<string, App>>();
 
             messageEventDTOs.ForEach(messageEventDTO =>
             {
                 App app = null;
 
-                if (messageEventDTO.MessageCreate.SourceAppId != null)
+                if (messageEventDTO.MessageCreate.SourceAppId != null && apps != null)
                 {
                     apps.TryGetValue(messageEventDTO.MessageCreate.SourceAppId.ToString(), out app);
                 }


### PR DESCRIPTION
When I create a Tweet mention from a web page I don't get any "apps" tag which causes the library throw an exception. It looks like that this tag is coupled to mobile phone apps.