### PR TITLE
Add functionality to try set `HttpClientHandler` properties

### DIFF
--- a/src/Tweetinvi.WebLogic/TwitterClientHandler.cs
+++ b/src/Tweetinvi.WebLogic/TwitterClientHandler.cs
@@ -19,8 +19,11 @@ namespace Tweetinvi.WebLogic
 
         public TwitterClientHandler(IOAuthWebRequestGenerator oAuthWebRequestGenerator)
         {
-            UseCookies = false;
-            UseDefaultCredentials = false;
+            TryAssignHandlerProperty(handler =>
+            {
+                handler.UseCookies = false;
+                handler.UseDefaultCredentials = false;
+            }, this);
 
             WebRequestGenerator = oAuthWebRequestGenerator;
         }
@@ -42,20 +45,23 @@ namespace Tweetinvi.WebLogic
             {
                 _twitterQuery = value;
 
-                if (value != null)
+                TryAssignHandlerProperty(handler =>
                 {
-                    Proxy = value.ProxyConfig;
-
-                    if (Proxy != null)
+                    if (value != null)
                     {
-                        UseProxy = true;
+                        handler.Proxy = value.ProxyConfig;
+
+                        if (handler.Proxy != null)
+                        {
+                            handler.UseProxy = true;
+                        }
                     }
-                }
-                else
-                {
-                    Proxy = null;
-                    UseProxy = false;
-                }
+                    else
+                    {
+                        handler.Proxy = null;
+                        handler.UseProxy = false;
+                    }
+                }, this);
             }
         }
 
@@ -116,6 +122,20 @@ namespace Tweetinvi.WebLogic
             });
 
             return base.SendAsync(request, cancellationToken);
+        }
+        
+        private static void TryAssignHandlerProperty(Action<HttpClientHandler> assignHandlerProperty, HttpClientHandler handler)
+        {
+            try
+            {
+                assignHandlerProperty?.Invoke(handler);
+            }
+            catch (PlatformNotSupportedException)
+            {
+                // If the platform is not supported these two properties are already "off"
+                // An example where this is problematic, the mono runtime:
+                // https://github.com/mono/mono/blob/7791e4d94206dd63acff49268b56a01c0b69983c/mcs/class/System.Net.Http/System.Net.Http/HttpClientHandler.xi.cs#L43
+            }
         }
     }
 }


### PR DESCRIPTION
Hi @linvi - thanks for this awesome project, I love it!

When using the TweetInvi library in mono, which is the case with Blazor WebAssembly - the [`HttpClientHandler`](https://github.com/mono/mono/blob/main/mcs/class/System.Net.Http/System.Net.Http/HttpClientHandler.xi.cs) does not support most of the properties. In fact, when you attempt to assign to them - they will:

```csharp
throw new PlatformNotSupportedException();
```

This pull request updates the .ctor and assignment of these properties behind encapsulated try/catch logic. If the platform is not supported for these, it shouldn't negatively affect the functionality of the app -- since they're being toggled off.

- Added try / catch logic to assign property values on the `HttpClientHandler` instance.
- See additional [notes here](https://github.com/linvi/tweetinvi/issues/1056#issuecomment-872526034).

Fixes #1056